### PR TITLE
Add merge capability

### DIFF
--- a/lib/YDStreamUtils.py
+++ b/lib/YDStreamUtils.py
@@ -201,10 +201,9 @@ def moveFile(file_path, dest_path, filename=None):
     destFilePath = os.path.join(dest_path, fname)
     if xbmcvfs.copy(file_path, destFilePath):
         xbmcvfs.delete(file_path)
-        return True
+        return destFilePath
 
-    return False
-
+    return ''
 
 def getDownloadPath(use_default=None):
     if use_default is None:

--- a/lib/YoutubeDLWrapper.py
+++ b/lib/YoutubeDLWrapper.py
@@ -59,7 +59,7 @@ except TypeError:
         class datetime(orig):
             @classmethod
             def strptime(cls, dstring, dformat):
-                return datetime.datetime(*(time.strptime(dstring, dformat)[0:6]))
+                return datetime(*(time.strptime(dstring, dformat)[0:6]))
 
             def __repr__(self):
                 return 'datetime.' + orig.__repr__(self)
@@ -338,10 +338,6 @@ def _getYTDL():
 def download(info):
     from youtube_dl import downloader
     ytdl = _getYTDL()
-    name = ytdl.prepare_filename(info)
     if 'http_headers' not in info:
         info['http_headers'] = std_headers
-    fd = downloader.get_suitable_downloader(info)(ytdl, ytdl.params)
-    for ph in ytdl._progress_hooks:
-        fd.add_progress_hook(ph)
-    return fd.download(name, info)
+    return ytdl.process_info(info)

--- a/lib/main.py
+++ b/lib/main.py
@@ -97,7 +97,7 @@ class main():
         util.LOG(repr(info), debug=True)
 
         from lib import YDStreamExtractor
-        YDStreamExtractor.handleDownload(info, bg=True)
+        YDStreamExtractor.handleDownload(info, filename=title, bg=True)
 
     def stopDownload(self):
         yes = xbmcgui.Dialog().yesno(T(32039), T(32040))

--- a/lib/yd_private_libs/servicecontrol.py
+++ b/lib/yd_private_libs/servicecontrol.py
@@ -31,7 +31,8 @@ class ServiceControl(object):
     def download(self, info, path, duration):
         addonPath = xbmcTranslatePath(util.ADDON.getAddonInfo('path')).decode('utf-8')
         service = os.path.join(addonPath, 'service.py')
-        data = {'data': info, 'path': path, 'duration': duration}
+        data = {'data': info, 'path': path, 'filename': filename, 'duration': duration}
+
         dataJSON = json.dumps(data)
         jsonqueue.XBMCJsonRAFifoQueue(util.QUEUE_FILE).push(binascii.hexlify(dataJSON))
         xbmc.executebuiltin('RunScript({0})'.format(service))

--- a/service.py
+++ b/service.py
@@ -53,7 +53,8 @@ class Service():
 
         while info and not monitor.abortRequested():
             t = threading.Thread(target=YDStreamExtractor._handleDownload, args=(
-                info['data'],), kwargs={'path': info['path'], 'duration': info['duration'], 'bg': True})
+                info['data'],), kwargs={'path': info['path'], 'filename': info['filename'],
+                                        'duration': info['duration'], 'bg': True})
             t.start()
 
             while t.is_alive():


### PR DESCRIPTION
Hi,

Some sites (francetv.fr notably) *only* provides separate audio and video files. The youtube-dl plugin does not support separate files and download a single video-only stream, without audio track (see issue in this project: https://github.com/Catch-up-TV-and-More/plugin.video.catchuptvandmore/issues/312).
The problem lies in YDStreamExtractor.getVideoInfo (which returns the video-only url) and in YoutubeDLWrapper.download (which bypasses the merge mechanism implemented in youtubeDL.py).
This pull request does not rely on getVideoInfo to get the requested video format. It uses instead the "format" option of YoutubeDL.py.
I've made a lot of tests, with no problem. But I'm not aware of every edge cases. So any advice would be very appreciated.

The PR also fixes issue https://github.com/ruuk/script.module.youtube.dl/issues/55 and allows to pass a preferred name for the downloaded file. ~~Extra parameters can also be passed to YoutubeDL throught the YoutubeDLWrapper class (mainly intended for *ffmpeg-location*)~~ [overrideParam mechanism restored, I misunderstood it at first].

The current api is normally not broken. But the proposed changes allow a simpler way for calling the download script:
```python
import YDStreamExtractor

# @quality is optional
info = {'url': 'http://www.youtube.com/watch?v=_yVv9dx88x0', 'quality': 1}

path = "/directory/where/we/want/the/video"
video_name = 'my downloaded file' 
result = YDStreamExtractor.handleDownload(info, bg=True, path=path, filename=video_name)
```
Thanks for all.